### PR TITLE
Remove extra white-spaces

### DIFF
--- a/src/main/java/cz/upce/fei/nnptp/zz/controller/main.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/controller/main.java
@@ -26,8 +26,7 @@ public class main {
         CryptoFile.writeFile(new File("test.txt"), "password",  contents);
         
         String read = CryptoFile.readFile(new File("test.txt"), "password");
-        System.out.println(read);
-        
+        System.out.println(read);     
     }
    
 }

--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/Parameter.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/Parameter.java
@@ -14,11 +14,10 @@ import java.time.LocalDateTime;
 public class Parameter {
     
     public static class StandardizedParameters {
-        public static final String  TITLE = "title" ;
-        public static final String  EXPIRATION_DATETIME  = "expiration-datetime" ;
-        public  static  final String  WEBSITE = "website" ;
-        public static final String  DESCRIPTION = "description" ;
-        
+        public static final String TITLE = "title";
+        public static final String EXPIRATION_DATETIME  = "expiration-datetime";
+        public static final String WEBSITE = "website";
+        public static final String DESCRIPTION = "description";
     }
     
     // TODO: add support for validation rules
@@ -39,8 +38,7 @@ public class Parameter {
 
         public void setValue(String value) {
             this.value = value;
-        }
-        
+        } 
     }
     
     public static class DateTimeParameter extends Parameter {
@@ -59,9 +57,7 @@ public class Parameter {
 
         public void setValue(LocalDateTime value) {
             this.value = value;
-        }
-        
-        
+        }    
     }
     
     public static class PasswordParameter extends Parameter {
@@ -80,8 +76,6 @@ public class Parameter {
 
         public void setPassword(String password) {
             this.password = password;
-        }
-        
-        
+        }     
     }
 }

--- a/src/main/java/cz/upce/fei/nnptp/zz/entity/PasswordDatabase.java
+++ b/src/main/java/cz/upce/fei/nnptp/zz/entity/PasswordDatabase.java
@@ -48,6 +48,5 @@ public class PasswordDatabase {
             }
         }
         return null;
-    }
-    
+    }    
 }


### PR DESCRIPTION
Remove extra white-spaces before semicolons in Parameter class and on another places.
